### PR TITLE
Update tag workflows trigger and naming

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -2,12 +2,11 @@ name: Build Tag & Publish to NuGet
 
 on:
     workflow_dispatch:
-    push:
-        tags:
-            - '*'
+    create:
 
 jobs:
     build:
+        if: startsWith(github.ref, 'refs/tags/')
         runs-on: windows-latest
         permissions:
             packages: read

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,4 +1,4 @@
-name: Tag on Merge to Stable
+name: Create Tag on Merge to stable
 permissions:
     contents: write
 


### PR DESCRIPTION
Changed build-tag workflow to trigger on 'create' events and added a conditional to run only for tag refs. Renamed create-tag workflow for clarity.